### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: main
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nbtca/Home/security/code-scanning/3](https://github.com/nbtca/Home/security/code-scanning/3)

To resolve the issue, add a `permissions:` block to the top/root of the workflow (directly under the `name:` or before `on:`). This will limit the GITHUB_TOKEN's permission for all jobs to the minimum necessary, which is `contents: read` for this workflow. No part of the shown workflow needs push/releases/issues write access, so this will not impact its operation.

**Change details:**  
- Insert a top-level `permissions:` block directly beneath `name: main` (line 1), so that it applies to all jobs unless explicitly overridden.
- No other code or file needs changes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
