### PR TITLE
Fix schedule loading race condition causing event flash

### DIFF
--- a/src/pages/calendar/Schedule.tsx
+++ b/src/pages/calendar/Schedule.tsx
@@ -110,62 +110,6 @@ const expandEventOccurrences = (
   return occurrences
 }
 
-const extractScheduleEvents = (icalComp: ICAL.Component): ScheduleEvent[] => {
-  const vevents = icalComp.getAllSubcomponents("vevent")
-  const rangeEnd = ICAL.Time.fromDateString("2026-01-01")
-  const rangeStart = ICAL.Time.fromDateString("2020-01-01")
-
-  // First, collect all exception events (events with RECURRENCE-ID)
-  const exceptions = new Map<string, Set<string>>() // uid -> set of recurrence-id strings
-  const exceptionEvents: ScheduleEvent[] = []
-
-  vevents.forEach((vevent) => {
-    const recurrenceId = vevent.getFirstPropertyValue("recurrence-id")
-    if (recurrenceId) {
-      const uid = vevent.getFirstPropertyValue("uid")
-      const event = new ICAL.Event(vevent)
-
-      // Check if exception is in range
-      if (event.startDate.compare(rangeEnd) <= 0 && event.endDate.compare(rangeStart) >= 0) {
-        exceptionEvents.push({
-          start: event.startDate.toJSDate(),
-          end: event.endDate.toJSDate(),
-          summary: event.summary,
-          description: event.description,
-          recurrenceId: recurrenceId.toString(),
-        })
-      }
-
-      // Track exception for filtering recurring events
-      if (!exceptions.has(uid)) {
-        exceptions.set(uid, new Set())
-      }
-      exceptions.get(uid)!.add(recurrenceId.toString())
-    }
-  })
-
-  // Process regular and recurring events
-  const regularEvents = vevents
-    .filter(vevent => !vevent.getFirstPropertyValue("recurrence-id"))
-    .flatMap<ScheduleEvent>((vevent) => {
-      const event = new ICAL.Event(vevent)
-      if (event.iterator().complete) {
-        return [{
-          start: event.startDate.toJSDate(),
-          end: event.endDate.toJSDate(),
-          summary: event.summary,
-          description: event.description,
-          recurrenceId: event.uid || event.startDate.toString(),
-        }]
-      }
-      const eventExceptions = exceptions.get(event.uid) || new Set()
-      return expandEventOccurrences(event, rangeStart, rangeEnd, eventExceptions)
-    })
-
-  return [...regularEvents, ...exceptionEvents]
-    .sort((a, b) => b.start.getTime() - a.start.getTime())
-}
-
 const formatTimePair = (s: Date, e: Date): string => {
   const start = dayjs(s)
   const end = dayjs(e)
@@ -215,14 +159,6 @@ export default function Schedule() {
       setScheduledEvents(events)
     }
   }, [focusedDate])
-
-  useEffect(() => {
-    setLoading(true)
-    parseCal().then((icalComp) => {
-      setScheduledEvents(extractScheduleEvents(icalComp))
-      setLoading(false)
-    })
-  }, [])
 
   const groupedEvents = useMemo(() => {
     const grouped = new Map<string, ScheduleEvent[]>()

--- a/src/pages/calendar/Schedule.tsx
+++ b/src/pages/calendar/Schedule.tsx
@@ -316,7 +316,7 @@ export default function Schedule() {
                       <span className="text-sm text-gray-600">{formatTimePair(event.start, event.end)}</span>
                       {
                         event.description && (
-                          <p className="mt-2">{event.description}</p>
+                          <p className="mt-2 whitespace-pre-wrap">{event.description}</p>
                         )
                       }
                     </div>


### PR DESCRIPTION
## Summary
- Fixed race condition where calendar would flash all events before showing month-filtered events
- Removed redundant useEffect that was competing with the month-filtering logic
- Now consistently shows only the current month's events on page load

## Problem
Two useEffects were running simultaneously on page load:
1. One for month filtering (`extractScheduleEventsInRange`)
2. One for loading all events (`extractScheduleEvents`)

This caused the calendar to briefly show all events, then switch to filtered events after a delay.

## Test plan
- [x] Test calendar page loads directly to current month's events
- [x] Verify no flash of all events before filtering
- [x] Ensure month navigation still works correctly
- [x] Check that initial loading behavior is consistent across page refreshes

🤖 Generated with [Claude Code](https://claude.ai/code)