### PR TITLE
fix: render HTML tags in calendar event descriptions

### DIFF
--- a/src/pages/calendar/Schedule.tsx
+++ b/src/pages/calendar/Schedule.tsx
@@ -317,7 +317,10 @@ export default function Schedule() {
                       <span className="text-sm text-gray-600">{formatTimePair(event.start, event.end)}</span>
                       {
                         event.description && (
-                          <p className="mt-2 whitespace-pre-wrap">{event.description}</p>
+                          <div
+                            className="mt-2 whitespace-pre-wrap"
+                            dangerouslySetInnerHTML={{ __html: event.description }}
+                          />
                         )
                       }
                     </div>


### PR DESCRIPTION
- Changed event description rendering from plain text to HTML
- Used dangerouslySetInnerHTML to properly display <br>, <a> and other HTML tags
- Changed container from <p> to <div> for better HTML compatibility

Fixes issue where HTML tags were displayed as raw text in calendar events