### PR TITLE
chore: mark package as private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "blog",
+  "private": true,
   "type": "module",
   "version": "0.0.1",
   "scripts": {


### PR DESCRIPTION
## Summary

- add `private: true` to the package manifest
- prevent accidental publication of this application package
- preserve dependency versions from the latest `origin/main`

## Impact

This adds a package-manager safeguard only; it does not change application runtime behavior.

## Validation

- parsed `package.json` successfully with Node.js
- confirmed `private` is exactly `true`
- confirmed `@hey-api/openapi-ts` remains at `^0.94.5`
- ran `git diff --check`
- verified the commit changes only `package.json` by one added line
