### PR TITLE
fix(docker): copy .npmrc before pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,12 @@ RUN corepack enable && corepack prepare pnpm@10.11.0 --activate
 WORKDIR /app
 
 FROM base AS build
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store HUSKY=0 pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm run build
+RUN grep -q 'bg-content1' dist/_astro/*.css \
+  || { echo "ERROR: no HeroUI utility classes in the CSS bundle; check .npmrc hoisting"; exit 1; }
 
 FROM nginx:alpine AS deploy
 COPY nginx.conf /etc/nginx/nginx.conf


### PR DESCRIPTION
Fixes #153.

Adds `.npmrc` to the files copied into the build stage before `pnpm install`, and asserts after the build that the bundle actually contains HeroUI classes.

`.npmrc` carries `public-hoist-pattern[]=*@heroui/*`, which is what hoists `@heroui/*` to the top level of `node_modules`. `tailwind.config.mjs` scans `./node_modules/@heroui/theme/dist/**`, so without it Tailwind emits no HeroUI utility classes — and still exits 0. Full analysis in #153.

## Verification

Built `851ef19` in Docker, before and after this change:

| | `.npmrc` in image | `@heroui/theme` hoisted | bundle | `rotate-180` | `bg-content1` |
|---|---|---|---|---|---|
| before | no | no | `index.DmAOLMjK.css` — 49,969 B | 0 | 0 |
| after | yes | yes | `index.Z1gKEliS.css` — 275,653 B | 1 | 1 |

The "before" row reproduces the bundle currently in production byte for byte.

The new assertion was checked by dropping `.npmrc` from the `COPY` line again — the build fails at that step instead of producing an image:

```
ERROR: no HeroUI utility classes in the CSS bundle; check .npmrc hoisting
```

## Notes

- `Dockerfile` only — no source, dependency or lockfile changes.
- The layer-caching split from #150 is preserved. `.npmrc` changes about as rarely as `package.json`, so the install layer stays cacheable.
